### PR TITLE
[RFC] Simplify to deploy pages with hugo

### DIFF
--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -5,44 +5,73 @@ on:
   push:
     paths:
       - src/**
+      - .github/workflows/generate_site_and_deploy.yaml
+      - .gitmodules
     branches:
       - hugo
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
 
 jobs:
   build:
     if: github.event.sender.login == 'pankona'
     runs-on: ubuntu-latest
     env:
-      TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      HUGO_VERSION: 0.113.0
     steps:
-    - name: setup go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '^1.16'
-    - name: clone pankona.github.com
+    - name: Install Hugo CLI
+      run: |
+        wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+        && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+    - name: Install Dart Sass Embedded
+      run: sudo snap install dart-sass-embedded
+    - name: Checkout
       uses: actions/checkout@v3
       with:
-        repository: pankona/pankona.github.com
-        path: pankona.github.com
-        submodules: 'recursive'
-    - name: clone hugo
-      uses: actions/checkout@v3
+        submodules: recursive
+        fetch-depth: 0
+    - name: Setup Pages
+      id: pages
+      uses: actions/configure-pages@v3
+    - name: Install Node.js dependencies
+      run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+    - name: Build with Hugo
+      env:
+        # For maximum backward compatibility with Hugo modules
+        HUGO_ENVIRONMENT: production
+        HUGO_ENV: production
+      run: |
+        cd src && hugo \
+          --gc \
+          --minify \
+          --baseURL "${{ steps.pages.outputs.base_url }}/"
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
       with:
-        repository: gohugoio/hugo
-        path: hugo
-    - name: install hugo
-      run: |
-        cd ./hugo
-        go install .
-    - name: git config
-      run: |
-        git config --global user.email "yosuke.akatsuka@gmail.com"
-        git config --global user.name "pankona"
-    - name: generate site and deploy
-      run: |
-        cd pankona.github.com
-        GITHUB_TOKEN=${TOKEN} make deploy
-    - name: update submodule
-      run: |
-        cd pankona.github.com
-        git add public && git commit -m "update submodule" && git push origin hugo
+        path: ./src/public
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
 [submodule "src/themes/purehugo"]
 	path = src/themes/purehugo
 	url = https://github.com/pankona/purehugo
-[submodule "public"]
-	path = public
-	url = https://github.com/pankona/pankona.github.com
-	branch = master

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,3 @@ all:
 
 serve:
 	make serve -C $(CURDIR)/src
-
-deploy:
-	make build -C $(CURDIR)/src
-	cd $(CURDIR)/public; \
-	git add . && git commit -m "Update site" && git push origin HEAD:master
-

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,8 +8,6 @@ endif
 
 build:
 	hugo
-	rm -rf $(CURDIR)/../public/*
-	mv public/* $(CURDIR)/../public/.
 
 serve:
 	hugo server -D --disableFastRender


### PR DESCRIPTION
Avoiding gitsubmodule except to manage the hugo theme

* Avoiding to depend https://github.com/peaceiris/actions-hugo because official doc https://gohugo.io/hosting-and-deployment/hosting-on-github/ does not refer to it
* After this, needed to bump HUGO_VERSION in workflow to use latest hugo
* Not yet tested 😋 