### PR TITLE
Prevent hugo warnings with `--panicOnWarning`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,15 +7,15 @@ else
 endif
 
 build:
-	hugo
+	hugo --panicOnWarning
 	rm -rf $(CURDIR)/../public/*
 	mv public/* $(CURDIR)/../public/.
 
 serve:
-	hugo server -D --disableFastRender
+	hugo --panicOnWarning server -D --disableFastRender
 
 newpost:
-	hugo new posts/$(post).md
+	hugo --panicOnWarning new posts/$(post).md
 
 edit:
 ifndef EDITOR


### PR DESCRIPTION
Might prevent some missing tasks to update hugo as #109 and #114