### PR TITLE
Fix Twitter username

### DIFF
--- a/src/hugo.toml
+++ b/src/hugo.toml
@@ -15,7 +15,7 @@ baseName = "atom"
 
 [params]
   description = "Good poem"
-  twitterName = "@pankona"
+  twitterName = "pankona"
   twitter = ""
   githubName = "pankona"
   google_analytics = "UA-48476608-2"


### PR DESCRIPTION
Currently handles as https://twitter.com/@pankona. It is redirected in PC browser, but mobile Twitter App does not redirect.

And https://www.gohugo.org/theme/purehugo/ reference does not include `@` prefix