### PR TITLE
Simplify usage of actions/checkout to follow #113

### DIFF
--- a/.github/workflows/generate_pr_from_issue.yaml
+++ b/.github/workflows/generate_pr_from_issue.yaml
@@ -15,24 +15,19 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '^1.16'
-    - name: clone pankona.github.com
-      uses: actions/checkout@v3
-      with:
-        repository: pankona/pankona.github.com
-        path: pankona.github.com
+    - uses: actions/checkout@v3
     - name: install articlegen
       run: |
-        cd ./pankona.github.com/tool/articlegen
+        cd ./tool/articlegen
         go install .
     - name: install makepr
       run: |
-        cd ./pankona.github.com/tool/makepr
+        cd ./tool/makepr
         go install .
     - name: commit
       env:
         ISSUE_TITLE: ${{ github.event.issue.title }}
       run: |
-        cd pankona.github.com
         title="$ISSUE_TITLE"
         title="${title//\[*\]/}"
         title=`echo $title | xargs`
@@ -51,7 +46,6 @@ jobs:
         title="${title//\[*\]/}"
         title=`echo $title | xargs`
         title="${title// /-}"
-        cd pankona.github.com
         git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all
         git push https://x-access-token:${TOKEN}@github.com/pankona/pankona.github.com.git ${title} -f
         GITHUB_TOKEN=${TOKEN} makepr --base="main" --head="${title}" --body="Resolves: ${{ github.event.issue.html_url }}"

--- a/.github/workflows/notify_long_time_no_see.yaml
+++ b/.github/workflows/notify_long_time_no_see.yaml
@@ -15,12 +15,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '^1.16'
-    - name: clone pankona.github.com
-      uses: actions/checkout@v3
-      with:
-        repository: pankona/pankona.github.com
-        path: pankona.github.com
-        submodules: 'recursive'
+    - uses: actions/checkout@v3
     - name: install sincelastcommit
       run: |
         cd ./tool/sincelastcommit


### PR DESCRIPTION
I think they are needed with the use of gitsubmodule, so now unnecessary since #113, because these actions are also not dependent on hugo themes.