### PR TITLE
Fix uncaught panic with shell use

### DIFF
--- a/.github/workflows/notify_long_time_no_see.yaml
+++ b/.github/workflows/notify_long_time_no_see.yaml
@@ -23,7 +23,8 @@ jobs:
         cd ..
     - name: check since last commit
       run: |
-        echo "SINCE_LAST_COMMIT=`sincelastcommit`" >> $GITHUB_ENV
+        days="$(sincelastcommit)"
+        echo "SINCE_LAST_COMMIT=${days}" >> $GITHUB_ENV
     - name: Slack Notification
       if: env.SINCE_LAST_COMMIT >= 7
       uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
This just fix use of danger shell use.

https://github.com/pankona/pankona.github.com/actions/runs/5248938742/jobs/9481107778

```
Run echo "SINCE_LAST_COMMIT=`sincelastcommit`" >> $GITHUB_ENV
  echo "SINCE_LAST_COMMIT=`sincelastcommit`" >> $GITHUB_ENV
  shell: /usr/bin/bash -e {0}
  env:
    TOKEN: ***
panic: object not found

goroutine 1 [running]:
main.main()
	/home/runner/work/pankona.github.com/pankona.github.com/tool/sincelastcommit/main.go:[2](https://github.com/pankona/pankona.github.com/actions/runs/5248938742/jobs/9481107778#step:6:2)[7](https://github.com/pankona/pankona.github.com/actions/runs/5248938742/jobs/9481107778#step:6:8) +0x1be
0s
0s
0s
0s
```

Still green and continued the steps.

Currently that does not raise error state even if the go tool raise panic.
This came from following behavior of bash.

```bash
> false
> echo $?
1
> echo "`false`"
> echo $?
0
```

I think these problems might be prevent by shellcheck as https://github.com/pankona/pankona.github.com/pull/130#issuecomment-1587500621
But the integration is another task 🙄 