### PR TITLE
Provide 404 page

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,14 @@
+{{ partial "header.html" . }}
+
+<div id="layout" class="pure-g">
+  {{ partial "sidebar.html" . }}
+
+  <div class="content pure-u-1 pure-u-md-3-4">
+    <div>
+        <h1 id="title"><a href="{{ "" | relURL }}">404 - make: command not found</a></h1>
+    </div>
+  </div>
+
+  {{ partial "analytics.html" . }}
+</body>
+</html>


### PR DESCRIPTION
今は404ページが無いので、リンク切れや過去の投稿で消されたものに当たった時に GitHub の用意したエラーが表示されてしまいます。
不安になるので、404ページがほしいなと思いました。

公式ではシンプルな例しか無いのですが、そのままだと purehugo との兼ね合いで何も表示されなかったので index.html から一部引用しています

https://github.com/pankona/purehugo/blob/6a5dab70f26d12a2da92b525bbed8234fb10d325/layouts/index.html

(template で partial があると、div がどこでどう nest して閉じられてるとかが非常に分かりづらい・・・結果のHTMLもインデントが壊れているし)