### PR TITLE
Use provided PAT for merging phase

### DIFF
--- a/.github/workflows/merge-bot-pr.yml
+++ b/.github/workflows/merge-bot-pr.yml
@@ -18,13 +18,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Wait other jobs
         # if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
-        uses: kachick/wait-other-jobs@v1.2.1
+        uses: kachick/wait-other-jobs@v1.3.0
         timeout-minutes: 30
-        with:
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
       - name: Approve and merge
         # if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
         run: gh pr review --approve "$PR_URL" && gh pr merge --auto --squash "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}'
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'


### PR DESCRIPTION
Closes https://github.com/pankona/pankona.github.com/pull/154

https://github.com/pankona/pankona.github.com/pull/151#discussion_r1228980044 に書いたように、マージ段階でPATを使うようにしました。

理由
---

マージされた時に他のアクションを走らせるのと、 https://github.com/pankona/pankona.github.com/pull/154 が https://github.com/pankona/pankona.github.com/pull/153 と連続で起きたからか

```
GraphQL: refusing to allow a GitHub App to create or update workflow `.github/workflows/merge-bot-pr.yml` without `workflows` permission (mergePullRequest)
```

というエラーが出ているからです。
自分のリポジトリでもこれは出てきてて、リベースしたら直りました。 GitHub CLI が最近このAPIを GraphQL 経由に変えて、RESTと微妙に違って制限があるとかかもしれませんが謎です。 https://github.com/cli/cli/issues/7574#issuecomment-1600709904 とかも微妙に違いそうだけど・・・ 🤔 