### PR TITLE
don't run typos in case of merging to main

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,8 +1,5 @@
 name: Typos
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
main にマージしたあとにチェックする必要はなさそう？