### PR TITLE
Add task to print dependency and the versions

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -21,4 +21,5 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v2
       - run: nix flake check
       - run: nix develop --command echo 'This step should be done before any other "nix develop" steps because of measuring Nix build time'
+      - run: nix develop --command make deps
       - run: nix develop --command make all

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,17 @@ ifndef EDITOR
 	EDITOR=vim
 endif
 	@cd $(CURDIR)/content/posts; $(EDITOR) `ls -t | peco`
+
+deps:
+	nix --version
+	hugo version
+	go version
+	make --version
+	dprint --version
+	typos --version
+	convert --version
+	actionlint --version
+	ls --version
+	nil --version
+	peco --version
+	vim --version | sed -n '1p'


### PR DESCRIPTION
これがベストプラクティスかは全くわからないんですが、簡単に依存先状況を確認できるようにしておくと便利なので追加出来ると嬉しいなーと

Makefile の肥大化が微妙であれば、 `tool/deps.bash` みたいに切り出しても良いです。

尚 nixpkgs-fmt はバージョン確認でエラーコード吐く多分バグがあるので入れていません。。。