### PR TITLE
Bump hugo version as used in flake.nix

### DIFF
--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -28,7 +28,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.113.0
+      # Keep same version with `make deps`
+      HUGO_VERSION: 0.117.0
     steps:
     - name: Install Hugo CLI
       run: |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # pankona.github.io
 
-using latest hugo
+Using the [Hugo](https://gohugo.io/) version specified in [the workflow](https://github.com/pankona/pankona.github.com/blob/main/.github/workflows/generate_site_and_deploy.yaml)


### PR DESCRIPTION
How about this change? The version is same as current flake.nix