### PR TITLE
Follow new structure since #168 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,14 +9,6 @@ updates:
     schedule:
       interval: 'daily'
   - package-ecosystem: 'gomod'
-    directory: '/tool/articlegen'
-    schedule:
-      interval: 'daily'
-  - package-ecosystem: 'gomod'
-    directory: '/tool/makepr'
-    schedule:
-      interval: 'daily'
-  - package-ecosystem: 'gomod'
-    directory: '/tool/sincelastcommit'
+    directory: '/tool'
     schedule:
       interval: 'daily'


### PR DESCRIPTION
#168 で go.mod が一箇所に集められましたが、この際 dependabot の config 更新が漏れていたようで長らく dependabot 更新対象になっていませんでした。(セキュリティアラートから #190 で強制的に上がった事によって気づけました。)

>きっと dependabot の pull request が減るはず

減りはした 🙄 
