### PR TITLE
Allow to create PRs even if labeled by other maintainers

### DIFF
--- a/.github/workflows/generate_pr_from_issue.yaml
+++ b/.github/workflows/generate_pr_from_issue.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   build:
-    if: (github.event.sender.login == 'pankona') && contains(github.event.issue.labels.*.name, 'article')
+    if: contains(github.event.issue.labels.*.name, 'article')
     runs-on: ubuntu-latest
     env:
       TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
https://github.com/pankona/pankona.github.com/pull/228#issuecomment-1922754392

現状 issueからPRを作る部分と、作られたPRからサイトをデプロイするところのどちらにも @pankona さんからの操作である事を確認する制限が入っています。

https://github.com/pankona/pankona.github.com/blob/9964c872c76c17bad70664db80046bdb3b060ef8/.github/workflows/generate_site_and_deploy.yaml#L74

しかし issue へラベルを付けられるのはメンバーだけだし、最終的にデプロイを止められれば僕が悪意を持っても大きな問題にはならないだろうということで、PR作成までは制限を緩めるといいのではと思いました！

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能改善**
	- GitHub Actionsワークフローのトリガー条件を変更し、「article」ラベルが付いたイシューに反応するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->