### PR TITLE
Fix query of searching GitHub PRs by the title

### DIFF
--- a/.github/workflows/generate_pr_from_issue.yaml
+++ b/.github/workflows/generate_pr_from_issue.yaml
@@ -52,7 +52,7 @@ jobs:
         title="${title//\[*\]/}"
         title=`echo $title | xargs`
         title="${title// /-}"
-        pr_number="$(gh pr list --search "<${title}>" --state open --json number --jq 'map(.number)[0]')"
+        pr_number="$(gh pr list --search "in:title ${title}" --state open --json number --jq 'map(.number)[0]')"
         git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all
         git push https://x-access-token:${TOKEN}@github.com/pankona/pankona.github.com.git ${title} -f
         GITHUB_TOKEN=${TOKEN} makepr --base="main" --head="${title}" --pr_number="${pr_number:0}" --body="Resolves: ${{ github.event.issue.html_url }}"


### PR DESCRIPTION
https://github.com/pankona/pankona.github.com/pull/232 は修正になっていなかったです。そもそもクエリの理解ができていなくて、 in:title と付与するのが正しいっぽい


https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments


