### PR TITLE
Fix to handle undefined variable in bash

### DIFF
--- a/.github/workflows/generate_pr_from_issue.yaml
+++ b/.github/workflows/generate_pr_from_issue.yaml
@@ -55,4 +55,4 @@ jobs:
         pr_number="$(gh pr list --search "in:title ${title}" --state open --json number --jq 'map(.number)[0]')"
         git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all
         git push https://x-access-token:${TOKEN}@github.com/pankona/pankona.github.com.git ${title} -f
-        GITHUB_TOKEN=${TOKEN} makepr --base="main" --head="${title}" --pr_number="${pr_number:0}" --body="Resolves: ${{ github.event.issue.html_url }}"
+        GITHUB_TOKEN=${TOKEN} makepr --base="main" --head="${title}" --pr_number="${pr_number:=0}" --body="Resolves: ${{ github.event.issue.html_url }}"


### PR DESCRIPTION
https://github.com/pankona/pankona.github.com/pull/228 のミスを直すPRで、PR番号自体が正しく「取れなかった」場合の処理を修正するものです
ローカルで試したときうまく言った気がしたんだけど、そのときは変数すでに定義済みだったのかも・・・？

https://github.com/pankona/pankona.github.com/actions/runs/7751820997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善点**
  - IssueからPull Requestを生成する際の`pr_number`パラメータの扱いを改善し、設定されていない場合はデフォルト値`0`を使用するように変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->