### PR TITLE
Specify PAT before fetch repository

### DIFF
--- a/.github/workflows/generate_pr_from_issue.yaml
+++ b/.github/workflows/generate_pr_from_issue.yaml
@@ -16,6 +16,10 @@ jobs:
       TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Needed to specify token for checkout phase, only in push phase is too late
+        # https://github.com/orgs/community/discussions/27072#discussioncomment-3254515
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     - name: setup go
       uses: actions/setup-go@v5
       with:
@@ -54,5 +58,5 @@ jobs:
         title="${title// /-}"
         pr_number="$(gh pr list --search "in:title ${title}" --state open --json number --jq 'map(.number)[0]')"
         git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all
-        git push --set-upstream origin ${title} --force-with-lease
+        git push origin ${title} --force-with-lease
         GITHUB_TOKEN=${TOKEN} makepr --base="main" --head="${title}" --pr_number="${pr_number:=0}" --body="Resolves: ${{ github.event.issue.html_url }}"


### PR DESCRIPTION
https://github.com/pankona/pankona.github.com/pull/230 後に issue を更新すると

https://github.com/pankona/pankona.github.com/actions/runs/7752339053/job/21141665250

>fatal: could not read Username for 'https://github.com/': No such device or address

と出るようになってました。
これはAI様のレビュー内容がおかし・・・ではなく頼り切っていた人間が不味かった気がするので以前ほかで書いたコードを見てみたところ、確か checkout 時に PAT 指定しとけみたいな内容だった気がします。

https://github.com/kachick/anylang-template/blob/529fabf83617247d31ae50c6c33addb540ffd8f4/.github/workflows/reusable-update-nixpkgs-and-versions-in-ci.yml#L62-L68

という、曖昧さに曖昧さで応えるPRです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- チェックアウトフェーズのタイミングの問題を解決するためにトークンが追加されました。
	- `git push` コマンドが `--force-with-lease` でオリジンにプッシュするように変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->