### PR TITLE
Add removed set-upstream flag

### DIFF
--- a/.github/workflows/generate_pr_from_issue.yaml
+++ b/.github/workflows/generate_pr_from_issue.yaml
@@ -60,5 +60,5 @@ jobs:
         title="${title// /-}"
         pr_number="$(gh pr list --search "in:title ${title}" --state open --json number --jq 'map(.number)[0]')"
         git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all
-        git push --force-with-lease
+        git push --set-upstream origin "${title}" --force-with-lease
         GITHUB_TOKEN=${TOKEN} makepr --base="main" --head="${title}" --pr_number="${pr_number:=0}" --body="Resolves: ${{ github.event.issue.html_url }}"


### PR DESCRIPTION
https://github.com/pankona/pankona.github.com/actions/runs/7752776832/job/21142858345

```
fatal: The current branch entering-ikukyu has no upstream branch.
To push the current branch and set the remote as upstream, use
    git push --set-upstream origin entering-ikukyu
To have this happen automatically for branches without a tracking
upstream, see 'push.autoSetupRemote' in 'git help config'.
```

https://github.com/pankona/pankona.github.com/pull/236 の checkout action 変更自体は正しく、その後の set-upstream 削除が余計だった。という気がする。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- リモートリポジトリへの変更のプッシュ方法を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->