### PR TITLE
Remove outdated config cleaner

### DIFF
--- a/.github/workflows/generate_pr_from_issue.yaml
+++ b/.github/workflows/generate_pr_from_issue.yaml
@@ -59,6 +59,5 @@ jobs:
         title=`echo $title | xargs`
         title="${title// /-}"
         pr_number="$(gh pr list --search "in:title ${title}" --state open --json number --jq 'map(.number)[0]')"
-        git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all
         git push --set-upstream origin "${title}" --force-with-lease
         GITHUB_TOKEN=${TOKEN} makepr --base="main" --head="${title}" --pr_number="${pr_number:=0}" --body="Resolves: ${{ github.event.issue.html_url }}"


### PR DESCRIPTION
push に失敗し続けているの、多分ここで一回 git config ふっとばしてるのが原因だ・・・

checkout 時に入ってくる情報を使う、URL指定はしないというのが現状なので、ここで情報をふっとばすとそれはうまくいかないよなーという