### PR TITLE
Force push again

### DIFF
--- a/.github/workflows/generate_pr_from_issue.yaml
+++ b/.github/workflows/generate_pr_from_issue.yaml
@@ -53,11 +53,12 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
         ISSUE_TITLE: ${{ github.event.issue.title }}
+      # "--force-with-lease" will not fit for upserting
       run: |
         title="$ISSUE_TITLE"
         title="${title//\[*\]/}"
         title=`echo $title | xargs`
         title="${title// /-}"
         pr_number="$(gh pr list --search "in:title ${title}" --state open --json number --jq 'map(.number)[0]')"
-        git push --set-upstream origin "${title}" --force-with-lease
+        git push --set-upstream origin "${title}" --force
         GITHUB_TOKEN=${TOKEN} makepr --base="main" --head="${title}" --pr_number="${pr_number:=0}" --body="Resolves: ${{ github.event.issue.html_url }}"


### PR DESCRIPTION
https://github.com/pankona/pankona.github.com/actions/runs/7753088096/job/21143749069

```
Run title="$ISSUE_TITLE"
To https://github.com/pankona/pankona.github.com
 ! [rejected]        entering-ikukyu -> entering-ikukyu (stale info)
error: failed to push some refs to 'https://github.com/pankona/pankona.github.com'
Error: Process completed with exit code 1.
```

https://github.com/pankona/pankona.github.com/pull/230#issuecomment-1922825052

`--force-with-lease` はこの場合不向きで、真面目に更新と add commit し続けるか force push するか。そして pankona さんは本件 force を優先。という理解
