### PR TITLE
Cache hugo modules

### DIFF
--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -31,13 +31,6 @@ jobs:
       # Keep same version with `make deps`
       HUGO_VERSION: 0.117.0
     steps:
-    - name: Cache hugo resources
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/.cache/hugo_cache
-        key: ${{ runner.os }}-hugo-v${{ env.HUGO_VERSION }}-hugomod-${{ hashFiles('go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-hugo-v${{ env.HUGO_VERSION }}-hugomod-
     - name: Install Hugo CLI
       run: |
         wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
@@ -47,6 +40,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     # Required go env because hugo module depends on it
+    - name: Cache hugo resources
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/.cache/hugo_cache
+        key: ${{ runner.os }}-hugo-v${{ env.HUGO_VERSION }}-hugomod-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-hugo-v${{ env.HUGO_VERSION }}-hugomod-
     - name: Set up Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -31,6 +31,12 @@ jobs:
       # Keep same version with `make deps`
       HUGO_VERSION: 0.117.0
     steps:
+    - uses: actions/cache@v4
+      with:
+        path: /home/runner/.cache/hugo_cache
+        key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-hugomod-
     - name: Install Hugo CLI
       run: |
         wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \

--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -31,7 +31,8 @@ jobs:
       # Keep same version with `make deps`
       HUGO_VERSION: 0.117.0
     steps:
-    - uses: actions/cache@v4
+    - name: Cache hugo resources
+      uses: actions/cache@v4
       with:
         path: /home/runner/.cache/hugo_cache
         key: ${{ runner.os }}-hugo-v${{ env.HUGO_VERSION }}-hugomod-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -34,9 +34,9 @@ jobs:
     - uses: actions/cache@v4
       with:
         path: /home/runner/.cache/hugo_cache
-        key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-hugo-v${{ env.HUGO_VERSION }}-hugomod-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-hugomod-
+          ${{ runner.os }}-hugo-v${{ env.HUGO_VERSION }}-hugomod-
     - name: Install Hugo CLI
       run: |
         wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \

--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/.cache/hugo_cache
-        key: ${{ runner.os }}-hugo-v${{ env.HUGO_VERSION }}-hugomod-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-hugo-v${{ env.HUGO_VERSION }}-hugomod-${{ hashFiles('go.sum') }}
         restore-keys: |
           ${{ runner.os }}-hugo-v${{ env.HUGO_VERSION }}-hugomod-
     - name: Install Hugo CLI


### PR DESCRIPTION
今 hugo の生成アクションに 1分以上、内生成部分が40秒程度と実際結構かかってるなーと思ってたんですが、どうもログを細かく見るとほとんど hugo module の fetch に時間がかかってるっぽいです。

https://github.com/peaceiris/actions-hugo/tree/aadc3a98dfd3437f8f97d436ea91b82a73dc85dd#%EF%B8%8F-caching-hugo-modules

を参考にして cache を適用してみました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- HugoリソースをキャッシュするためのステップをGitHub Actionsに追加しました。これにより、OS、Hugoのバージョン、および`go.sum`のハッシュに基づいてパス、キー、復元キーを指定します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->