### PR TITLE
Improve gh query

### DIFF
--- a/.github/workflows/generate_pr_from_issue.yaml
+++ b/.github/workflows/generate_pr_from_issue.yaml
@@ -59,6 +59,6 @@ jobs:
         title="${title//\[*\]/}"
         title=`echo $title | xargs`
         title="${title// /-}"
-        pr_number="$(gh pr list --search "in:title ${title}" --state open --json number --jq 'map(.number)[0]')"
+        pr_number="$(gh pr list --author "@me" --search "in:title ${title}" --state open --json number --jq 'map(.number)[0]')"
         git push --set-upstream origin "${title}" --force
         GITHUB_TOKEN=${TOKEN} makepr --base="main" --head="${title}" --pr_number="${pr_number:=0}" --body="Resolves: ${{ github.event.issue.html_url }}"

--- a/.github/workflows/generate_pr_from_issue.yaml
+++ b/.github/workflows/generate_pr_from_issue.yaml
@@ -59,6 +59,6 @@ jobs:
         title="${title//\[*\]/}"
         title=`echo $title | xargs`
         title="${title// /-}"
-        pr_number="$(gh pr list --author "@me" --search "in:title ${title}" --state open --json number --jq 'map(.number)[0]')"
+        pr_number="$(gh pr list --author "@me" --head "${title}" --state open --json number --jq 'map(.number)[0]')"
         git push --set-upstream origin "${title}" --force
         GITHUB_TOKEN=${TOKEN} makepr --base="main" --head="${title}" --pr_number="${pr_number:=0}" --body="Resolves: ${{ github.event.issue.html_url }}"


### PR DESCRIPTION
https://github.com/pankona/pankona.github.com/pull/228 で既存のPRを再利用するようにした後しばらく、ヒット数が0の時とかの動作がバグってて全然関係ないPRが更新されてしまいました。
~~他人のブログとはいえ~~危険だなと思ったので、制限を厳しくするクエリに書き換えてみました。
ご査収ください

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能向上**
	- タイトルと著者に基づいてプルリクエスト番号を取得するコマンドを変更し、プルリクエスト作成の自動化を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->