### PR TITLE
Update nixpkgs and the hugo

### DIFF
--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Keep same version with `make deps`
-      HUGO_VERSION: 0.117.0
+      HUGO_VERSION: 0.122.0
     steps:
     - name: Install Hugo CLI
       run: |

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692734709,
-        "narHash": "sha256-SCFnyHCyYjwEmgUsHDDuU0TsbVMKeU1vwkR+r7uS2Rg=",
+        "lastModified": 1706913249,
+        "narHash": "sha256-x3M7iV++CsvRXI1fpyFPduGELUckZEhSv0XWnUopAG8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b85ed9dcbf187b909ef7964774f8847d554fab3b",
+        "rev": "e92b6015881907e698782c77641aa49298330223",
         "type": "github"
       },
       "original": {

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ github.com/pankona/purehugo v0.0.0-20231123145602-5ea1723e15f0 h1:4CO2OtpcvDcrJc
 github.com/pankona/purehugo v0.0.0-20231123145602-5ea1723e15f0/go.mod h1:mGJrf/ZAQlGvpweyOY7mlNg3R8X+/OTGoXVBQ+nu3tw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.18.0 h1:PGVlW0xEltQnzFZ55hkuX5+KLyrMYhHld1YHO4AKcdc=
 golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=


### PR DESCRIPTION
nixpkgs を上げつつ、伴って hugo も上げています。
別にhugo自体は今のままで困ってないんですが、YAMLの変更が多いこともあって dprint + plugin か yamlfmt 導入したい、その下準備として先に上げておくという感じです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- サイト生成とデプロイのためのワークフローで使用されるHUGOのバージョンを`0.117.0`から`0.122.0`に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->