### PR TITLE
Update nixpkgs and go version to 1.22

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706913249,
-        "narHash": "sha256-x3M7iV++CsvRXI1fpyFPduGELUckZEhSv0XWnUopAG8=",
+        "lastModified": 1707863367,
+        "narHash": "sha256-LdBbCSSP7VHaHA4KXcPGKqkvsowT2+7W4jlEHJj6rPg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e92b6015881907e698782c77641aa49298330223",
+        "rev": "35ff7e87ee05199a8003f438ec11a174bcbd98ea",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
               bashInteractive
 
               hugo
-              go_1_21
+              go_1_22
               gnumake
               coreutils
               peco

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/pankona/pankona.github.com
 
-go 1.21
-
-toolchain go1.21.0
+go 1.22.0

--- a/tool/go.mod
+++ b/tool/go.mod
@@ -1,8 +1,6 @@
 module github.com/pankona/pankona.github.com/tool
 
-go 1.21
-
-toolchain go1.21.0
+go 1.22.0
 
 require (
 	github.com/google/go-github/v33 v33.0.0


### PR DESCRIPTION
やりたいこと
---

- 考えること減らせるから go のバージョンを最新に上げておきたい

やったこと
---

- 現行の Nix flake の 指してる先はまだ RC だったので、最新に上げておきました。hugo とか dprint みたいに他のバージョン指定をCIでしてる物の更新はなさそうでした。
- go.mod を更新した。いつもどう更新するか迷うんだけど tidy だけだと部分的に更新されないことあるよなーと思って↓のドキュメント読んでたら go get で良さげな事が書いてあったので掛けてみました。 build みたいに パス指定できない？ なんで toolchain 消えるんだ？ という気がしなくもないのでレビューお願いします。 https://github.com/golang/go/issues/62278 は軽くウォッチしている

やらなかったこと
---

- https://tip.golang.org/doc/go1.22 を軽く眺めた限り特にこのリポジトリで必要というか何か対応した方が良さそうな変更箇所は思いつかなかったんですが、そこは専門家におまかせします！