### PR TITLE
Prefer stable Nix packages for bash and basics

### DIFF
--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Keep same version with `make deps`
-      HUGO_VERSION: 0.122.0
+      HUGO_VERSION: 0.124.1
     steps:
       - name: Install Hugo CLI
         run: |

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "edge-nixpkgs": {
+      "locked": {
+        "lastModified": 1712122226,
+        "narHash": "sha256-pmgwKs8Thu1WETMqCrWUm0CkN1nmCKX3b51+EXsAZyY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "08b9151ed40350725eb40b1fe96b0b86304a654b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -20,22 +36,23 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707863367,
-        "narHash": "sha256-LdBbCSSP7VHaHA4KXcPGKqkvsowT2+7W4jlEHJj6rPg=",
+        "lastModified": 1711668574,
+        "narHash": "sha256-u1dfs0ASQIEr1icTVrsKwg2xToIpn7ZXxW3RHfHxshg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "35ff7e87ee05199a8003f438ec11a174bcbd98ea",
+        "rev": "219951b495fc2eac67b1456824cc1ec1fd2ee659",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "edge-nixpkgs": "edge-nixpkgs",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,14 +1,16 @@
 {
   inputs = {
     # How to update the revision: `nix flake update --commit-lock-file`
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    edge-nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, edge-nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        edge-pkgs = edge-nixpkgs.legacyPackages.${system};
       in
       {
         devShells.default = with pkgs;
@@ -17,19 +19,20 @@
               # https://github.com/NixOS/nix/issues/730#issuecomment-162323824
               bashInteractive
 
-              hugo
-              go_1_22
               gnumake
               coreutils
               peco
-              typos
-              dprint
               yamlfmt
+              typos
               imagemagick
               actionlint
               nil
               nixpkgs-fmt
               vim
+
+              edge-pkgs.hugo
+              edge-pkgs.go_1_22
+              edge-pkgs.dprint
             ];
           };
       });

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/pankona/pankona.github.com
 
 go 1.22.0
+
+require github.com/pankona/purehugo v0.0.0-20231123145602-5ea1723e15f0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pankona/purehugo v0.0.0-20231123145602-5ea1723e15f0 h1:4CO2OtpcvDcrJcpbtj5IksapN9H8RAY7fRTsPXds+T4=
+github.com/pankona/purehugo v0.0.0-20231123145602-5ea1723e15f0/go.mod h1:mGJrf/ZAQlGvpweyOY7mlNg3R8X+/OTGoXVBQ+nu3tw=


### PR DESCRIPTION
Import https://github.com/kachick/anylang-template/pull/80

I'm positive only use stable nixpkgs in this repo, but remain unstable ref to avoid regression for hugo
Reconsider after nixos-24.05

I want to use latest typos as GitHub actions, but https://github.com/NixOS/nixpkgs/pull/301147 is not yet applied to the channel. So changed to stable package here. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- サイト生成とデプロイ用の設定ファイルを更新し、HUGOのバージョンを0.122.0から0.124.1にアップグレードしました。
	- NixパッケージのURLを更新し、開発環境の設定に新しいパッケージを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->