### PR TITLE
Replace dart-sass-embedded with dart-sass

### DIFF
--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -35,8 +35,8 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-      - name: Install Dart Sass Embedded
-        run: sudo snap install dart-sass-embedded
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
       - name: Checkout
         uses: actions/checkout@v4
       # Required go env because hugo module depends on it


### PR DESCRIPTION
https://github.com/sass/dart-sass-embedded/commit/4190c318d42a013414a565195e23e0652fb5651f

ref #276, but cannot fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Dart Sassのインストールコマンドを"dart-sass-embedded"から"dart-sass"に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->