### PR TITLE
Install tools to use hugo with Nix to avoid unstable snap

### DIFF
--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -31,11 +31,13 @@ jobs:
           key: ${{ runner.os }}-flake-${{ hashFiles('flake.lock') }}-hugomod-${{ hashFiles('go.sum') }}
           restore-keys: |
             ${{ runner.os }}-flake-${{ hashFiles('flake.lock') }}-hugomod-
-      - uses: DeterminateSystems/nix-installer-action@v10
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
+      - uses: DeterminateSystems/nix-installer-action@v10
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
+      - name: Build hugo-nix to measure how longtime used to build
+        run: 'nix run .#hugo-nix -- version'
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && nix develop --command npm ci || true"
       # Required go env before this step because hugo module depends on it. Now whole setup is completed with Nix

--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -21,43 +21,31 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      # Keep same version with `make deps`
-      HUGO_VERSION: 0.124.1
     steps:
-      - name: Install Hugo CLI
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-      - name: Install Dart Sass
-        run: sudo snap install dart-sass
       - name: Checkout
         uses: actions/checkout@v4
-      # Required go env because hugo module depends on it
       - name: Cache hugo resources
         uses: actions/cache@v4
         with:
           path: /home/runner/.cache/hugo_cache
-          key: ${{ runner.os }}-hugo-v${{ env.HUGO_VERSION }}-hugomod-${{ hashFiles('go.sum') }}
+          key: ${{ runner.os }}-flake-${{ hashFiles('flake.lock') }}-hugomod-${{ hashFiles('go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-hugo-v${{ env.HUGO_VERSION }}-hugomod-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache-dependency-path: 'go.sum'
+            ${{ runner.os }}-flake-${{ hashFiles('flake.lock') }}-hugomod-
+      - uses: DeterminateSystems/nix-installer-action@v10
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
       - name: Install Node.js dependencies
-        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && nix develop --command npm ci || true"
+      # Required go env before this step because hugo module depends on it. Now whole setup is completed with Nix
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
-          hugo --panicOnWarning \
+          nix run .#hugo-nix -- --panicOnWarning \
             --gc \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"

--- a/flake.nix
+++ b/flake.nix
@@ -30,10 +30,31 @@
               nixpkgs-fmt
               vim
 
+              edge-pkgs.dprint
+
               edge-pkgs.hugo
               edge-pkgs.go_1_22
-              edge-pkgs.dprint
+              dart-sass
             ];
           };
-      });
+
+        apps = {
+          hugo-nix = {
+            type = "app";
+            program = with pkgs;lib.getExe (writeShellApplication
+              {
+                name = "hugo-with-dependencies";
+                runtimeInputs = [
+                  edge-pkgs.hugo
+                  edge-pkgs.go_1_22
+                  dart-sass
+                ];
+                text = ''
+                  hugo "$@"
+                '';
+              });
+          };
+        };
+      }
+    );
 }


### PR DESCRIPTION
Fixes #276

Nix を使うと Nix 自体のセットアップに掛かるところでオーバーヘッドかかったりもしがちなんですが、今回は snap を使った dart-sass のインストールが遅すぎるということでトータルで見ると10倍近く高速化しました。
なるべく既存コードへ差異がでないように差し込んだのでメンテナンスコストは大幅に上がったりしないんじゃないかなと思うんですけどどうでしょう？
(他には brew を使ってsnapいれるとかも有りそう。試しては居ないです)

Before
---

Total 7.5~12 minutes

![image](https://github.com/pankona/pankona.github.com/assets/1180335/5957507a-3a78-4761-b89e-8d092a554aa1)

![image](https://github.com/pankona/pankona.github.com/assets/1180335/bbe7ef28-e9fd-40d3-8acf-16ab4df72795)


After
---

Total 1.3~1.5 minutes

![image](https://github.com/pankona/pankona.github.com/assets/1180335/464f5f5e-1ad3-440c-a6d1-b3c1a024e05d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- `edge-pkgs.dprint`をパッケージリストに追加しました。
	- 特定の設定を持つ`hugo-nix`の新しいエントリを`apps`セクションに含めるように変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->