### PR TITLE
Bump and pin to NixOS 24.05 nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "edge-nixpkgs": {
-      "locked": {
-        "lastModified": 1712122226,
-        "narHash": "sha256-pmgwKs8Thu1WETMqCrWUm0CkN1nmCKX3b51+EXsAZyY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "08b9151ed40350725eb40b1fe96b0b86304a654b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,23 +20,22 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711668574,
-        "narHash": "sha256-u1dfs0ASQIEr1icTVrsKwg2xToIpn7ZXxW3RHfHxshg=",
+        "lastModified": 1719956923,
+        "narHash": "sha256-nNJHJ9kfPdzYsCOlHOnbiiyKjZUW5sWbwx3cakg3/C4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "219951b495fc2eac67b1456824cc1ec1fd2ee659",
+        "rev": "706eef542dec88cc0ed25b9075d3037564b2d164",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "edge-nixpkgs": "edge-nixpkgs",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,14 @@
 {
   inputs = {
     # How to update the revision: `nix flake update --commit-lock-file`
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
-    edge-nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, edge-nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        edge-pkgs = edge-nixpkgs.legacyPackages.${system};
       in
       {
         devShells.default = with pkgs;
@@ -30,10 +28,10 @@
               nixpkgs-fmt
               vim
 
-              edge-pkgs.dprint
+              dprint
 
-              edge-pkgs.hugo
-              edge-pkgs.go_1_22
+              hugo
+              go_1_22
               dart-sass
             ];
           };
@@ -45,8 +43,8 @@
               {
                 name = "hugo-with-dependencies";
                 runtimeInputs = [
-                  edge-pkgs.hugo
-                  edge-pkgs.go_1_22
+                  hugo
+                  go_1_22
                   dart-sass
                 ];
                 text = ''


### PR DESCRIPTION
## Before

```console
> make deps
nix --version
nix (Nix) 2.21.2
hugo version
hugo v0.124.1+extended linux/amd64 BuildDate=unknown VendorInfo=nixpkgs
go version
go version go1.22.1 linux/amd64
make --version
GNU Make 4.4.1
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
dprint --version
dprint 0.45.0
typos --version
typos-cli 1.16.23
convert --version
Version: ImageMagick 7.1.1-29 Q16-HDRI x86_64 cfc71f0aa:20240225 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): bzlib cairo djvu fontconfig freetype heic jng jp2 jpeg jxl lcms lqr lzma openexr pangocairo png raw rsvg tiff webp x xml zlib zstd
Compiler: gcc (12.3)
actionlint --version
1.6.26
installed by building from source
built with go1.21.8 compiler for linux/amd64
ls --version
ls (GNU coreutils) 9.3
Packaged by https://nixos.org
Copyright (C) 2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Richard M. Stallman and David MacKenzie.
nil --version
nil 2023-08-09
peco --version
peco version v0.5.11 (built with go1.21.8)
vim --version | sed -n '1p'
VIM - Vi IMproved 9.0 (2022 Jun 28, compiled Jan 01 1980 00:00:00)
```

## After

```console
> make deps
nix --version
nix (Nix) 2.21.2
hugo version
hugo v0.126.1+extended linux/amd64 BuildDate=unknown VendorInfo=nixpkgs
go version
go version go1.22.4 linux/amd64
make --version
GNU Make 4.4.1
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
dprint --version
dprint 0.45.1
typos --version
typos-cli 1.21.0
convert --version
Version: ImageMagick 7.1.1-32 Q16-HDRI x86_64 e1de8c5eb:20240505 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): bzlib cairo djvu fontconfig freetype heic jng jp2 jpeg jxl lcms lqr lzma openexr pangocairo png raw rsvg tiff webp x xml zlib zstd
Compiler: gcc (13.2)
actionlint --version
1.7.0
installed by building from source
built with go1.22.4 compiler for linux/amd64
ls --version
ls (GNU coreutils) 9.5
Packaged by https://nixos.org
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Richard M. Stallman and David MacKenzie.
nil --version
nil 2023-08-09
peco --version
peco version v0.5.11 (built with go1.22.4)
vim --version | sed -n '1p'
VIM - Vi IMproved 9.1 (2024 Jan 02, compiled Jan 01 1980 00:00:00)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependencies to use stable versions of `dprint`, `hugo`, and `go_1_22`.
	- Removed references to `edge-nixpkgs` for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->