### PR TITLE
Add missing push trigger for linter workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 name: Lint
 on:
+  push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
539bb695dbf9e0b97169c1abe769495d581ab2bd に於いて、
markdown だけでなく GitHub Action の workflow にも変更が掛かっているのは本来おかしい
ダイレクト push による変更が検知できなかったものと思われる
