### PR TITLE
Fix a typo `s/inventry/inventory/`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.25.0
+      - uses: crate-ci/typos@v1.27.0
         with:
           # https://github.com/crate-ci/typos/issues/779#issuecomment-1635761199
           files: |

--- a/content/posts/golangtokyo.md
+++ b/content/posts/golangtokyo.md
@@ -198,7 +198,7 @@ Go でデバッガといえば [delve](https://github.com/derekparker/delve) か
 ### Q. デプロイまでのフロート工夫している点。CIとか。
 
 - kaneshin さん >
-  - ansible。dynamic inventry を使っている。
+  - ansible。dynamic inventory を使っている。
 
 #### ところで、Go のビルドが遅くなる理由
 


### PR DESCRIPTION
https://github.com/pankona/pankona.github.com/pull/320 の 🔴 で気づいたのですが、最新の typos で `inventry` というスペルが検出されてました。

@pankona 多分 typo だと思うのですが、一応確認お願いします！