### PR TITLE
Refine flake style and update the formatter and LSP

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,15 @@
   "[nix]": {
     "editor.defaultFormatter": "jnoortheen.nix-ide"
   },
+  "nix.serverPath": "nixd",
+  "nix.serverSettings": {
+    "nixd": {
+      "formatting": {
+        "command": ["nixfmt"]
+      }
+    }
+  },
+  "nix.enableLanguageServer": true,
   "[go]": {
     "editor.defaultFormatter": "golang.go"
   }

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ deps:
 	convert --version
 	actionlint --version
 	ls --version
-	nil --version
+	nixfmt --version
+	nixd --version
 	peco --version
 	vim --version | sed -n '1p'
 	markdownlint-cli2 --version | grep 'markdownlint v'

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1719956923,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },


### PR DESCRIPTION
- もうすぐ NixOS 24.11 への更新時期なので、その前に現状を整えておく
- GH-326 で yaml-language-server を導入しようとしたときに formatter 関係で引っかかる等して辛かったので更新しておきたい
- 現行のチャンネルと関連lockは上がっていないので、hugo周りへの影響等は出ない筈
