### PR TITLE
Refine printing dependencies

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -2,11 +2,19 @@ name: CI - Nix
 on:
   push:
     branches: [main]
+    paths:
+      - '.github/workflows/ci-nix.yml'
+      - '*.nix'
+      - 'flake.*'
+      - 'Makefile'
+      - 'print_dependencies.bash'
   pull_request:
     paths:
       - '.github/workflows/ci-nix.yml'
       - '*.nix'
       - 'flake.*'
+      - 'Makefile'
+      - 'print_dependencies.bash'
   schedule:
     # Every 10:42 JST
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,4 @@ endif
 	@cd $(CURDIR)/content/posts; $(EDITOR) `ls -t | peco`
 
 deps:
-	nix --version
-	hugo version
-	go version
-	make --version
-	dprint --version
-	typos --version
-	convert --version
-	actionlint --version
-	ls --version
-	nixfmt --version
-	nixd --version
-	peco --version
-	vim --version | sed -n '1p'
-	markdownlint-cli2 --version | grep 'markdownlint v'
+	./print_dependencies.bash

--- a/print_dependencies.bash
+++ b/print_dependencies.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+nix --version
+hugo version
+sass --version
+go version
+make --version
+dprint --version
+typos --version
+convert --version
+actionlint --version
+ls --version
+nixfmt --version
+nixd --version
+peco --version
+vim --version | sed -n '1p'
+markdownlint-cli2 --version | grep 'markdownlint v'


### PR DESCRIPTION
Enable set -x to clarify which tool output the version string

Extract to another file to keep simple Makefile

Preint sass version for GH-328
