### PR TITLE
Bump go version to 1.23

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
               dprint
 
               hugo
-              go_1_22
+              go_1_23
               dart-sass
 
               markdownlint-cli2
@@ -61,7 +61,7 @@
                 name = "hugo-with-dependencies";
                 runtimeInputs = with pkgs; [
                   hugo
-                  go_1_22
+                  go_1_23
                   dart-sass
                 ];
                 text = ''

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/pankona/pankona.github.com
 
-go 1.22.0
+go 1.23.1
 
 require github.com/pankona/purehugo v0.0.0-20231123145602-5ea1723e15f0 // indirect

--- a/tool/go.mod
+++ b/tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/pankona/pankona.github.com/tool
 
-go 1.22.0
+go 1.23.1
 
 require (
 	github.com/google/go-github/v33 v33.0.0


### PR DESCRIPTION
- **Bump go version to 1.23 in flake**
- **Update go.mod and go.sum**

go の version をあげてみました。
それだけというか、特に既存実装側は触っていないので、なにか必要であればお願いします！


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Go programming language version to 1.23.1 across various modules, enhancing performance and compatibility.
	- Added a new requirement for the `github.com/pankona/purehugo` module.

- **Bug Fixes**
	- Resolved potential issues related to the previous Go version by ensuring all modules are up-to-date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->