### PR TITLE
Bump to nixos-24.11 channel

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dprint/check@v2.2
         with:
-          dprint-version: 0.45.0
+          dprint-version: 0.47.2
       - name: Debug print for deprint target paths
         run: dprint output-file-paths
 
@@ -33,6 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@3aaa38e446fbd2c288af4291aa0f55d64651050f # v12
+      - uses: DavidAnson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530809 # v17
         with:
           globs: '**/*.md'

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730963269,
-        "narHash": "sha256-rz30HrFYCHiWEBCKHMffHbMdWJ35hEkcRVU0h7ms3x0=",
+        "lastModified": 1732350895,
+        "narHash": "sha256-GcOQbOgmwlsRhpLGSwZJwLbo3pu9ochMETuRSS1xpz4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "83fb6c028368e465cd19bb127b86f971a5e41ebc",
+        "rev": "0c582677378f2d9ffcb01490af2f2c678dcb29d3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     # How to update the revision: `nix flake update --commit-lock-file`
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
   };
 
   outputs =

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/pankona/pankona.github.com
 
-go 1.23.1
+go 1.23.3
 
 require github.com/pankona/purehugo v0.0.0-20231123145602-5ea1723e15f0 // indirect


### PR DESCRIPTION
特に hugo と sass のバージョンが上がることで https://github.com/pankona/pankona.github.com/pull/279 以降実際の生成物にも影響するので、そこの確認だけはお願いしたく

![image](https://github.com/user-attachments/assets/48f0cffe-ce5f-48b6-b2b0-35e4fac3c95f)

パット見大きく崩れていなさそうではある(そんな正確に元のを把握しているわけではないけれど、違和感がどんだけあるかという基準で)

---

## Before

```console
> make deps
./print_dependencies.bash
+ nix --version
nix (Nix) 2.24.10
+ hugo version
hugo v0.126.1+extended linux/amd64 BuildDate=unknown VendorInfo=nixpkgs
+ sass --version
1.77.2
+ go version
go version go1.23.1 linux/amd64
+ make --version
GNU Make 4.4.1
このプログラムは x86_64-pc-linux-gnu 用にビルドされました
Copyright (C) 1988-2023 Free Software Foundation, Inc.
ライセンス GPLv3+: GNU GPL バージョン 3 以降 <https://gnu.org/licenses/gpl.html>
これはフリーソフトウェアです: 自由に変更および配布できます.
法律の許す限り、　無保証　です.
+ dprint --version
dprint 0.45.1
+ typos --version
typos-cli 1.21.0
+ convert --version
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"

Version: ImageMagick 7.1.1-39 Q16-HDRI x86_64 e339a05ed:20241002 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): bzlib cairo djvu fontconfig freetype heic jng jp2 jpeg jxl lcms lqr lzma openexr pangocairo png raw rsvg tiff webp x xml zlib zstd
Compiler: gcc (13.2)
+ actionlint --version
1.7.0
installed by building from source
built with go1.22.8 compiler for linux/amd64
+ ls --version
ls (GNU coreutils) 9.5
Packaged by https://nixos.org
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Richard M. Stallman and David MacKenzie.
+ nixfmt --version
nixfmt v0.6.0
+ nixd --version
nixd, version: 2.1.2
+ peco --version
peco version v0.5.11 (built with go1.22.8)
+ vim --version
+ sed -n 1p
VIM - Vi IMproved 9.1 (2024 Jan 02, compiled Jan 01 1980 00:00:00)
+ markdownlint-cli2 --version
+ grep 'markdownlint v'
markdownlint-cli2 v0.9.0 (markdownlint v0.30.0)
```

## After

```console
> make deps
./print_dependencies.bash
+ nix --version
nix (Nix) 2.24.10
+ hugo version
hugo v0.136.5+extended linux/amd64 BuildDate=unknown VendorInfo=nixpkgs
+ sass --version
1.80.5
+ go version
go version go1.23.3 linux/amd64
+ make --version
GNU Make 4.4.1
このプログラムは x86_64-pc-linux-gnu 用にビルドされました
Copyright (C) 1988-2023 Free Software Foundation, Inc.
ライセンス GPLv3+: GNU GPL バージョン 3 以降 <https://gnu.org/licenses/gpl.html>
これはフリーソフトウェアです: 自由に変更および配布できます.
法律の許す限り、　無保証　です.
+ dprint --version
dprint 0.47.2
+ typos --version
typos-cli 1.27.3
+ convert --version
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"

Version: ImageMagick 7.1.1-40 Q16-HDRI x86_64 08de3ab43:20241109 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): bzlib cairo djvu fftw fontconfig freetype heic jng jp2 jpeg jxl lcms lqr lzma openexr pangocairo png raw rsvg tiff webp x xml zlib zstd
Compiler: gcc (13.3)
+ actionlint --version
1.7.4
installed by building from source
built with go1.23.3 compiler for linux/amd64
+ ls --version
ls (GNU coreutils) 9.5
Packaged by https://nixos.org
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Richard M. Stallman and David MacKenzie.
+ nixfmt --version
nixfmt nixpkgs-unstable-2024-08-16
+ nixd --version
nixd, version: 2.5.1
+ peco --version
peco version v0.5.11 (built with go1.23.3)
+ vim --version
+ sed -n 1p
VIM - Vi IMproved 9.1 (2024 Jan 02, compiled Jan 01 1980 00:00:00)
+ markdownlint-cli2 --version
+ grep 'markdownlint v'
markdownlint-cli2 v0.14.0 (markdownlint v0.35.0)
```
