### PR TITLE
Replace DeterminateSystems/nix-installer-action with cachix/install-nix-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
-    groups:
-      nix:
-        patterns:
-          - 'DeterminateSystems*'
     ignore:
       # They do not support specifying a version in the latest action. Therefore, we need to pin the version for nixpkgs compatibility.
       # See https://github.com/DavidAnson/markdownlint-cli2-action/issues/94 for detail

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: cachix/install-nix-action@v31
       - run: nix flake check
       - run: nix develop --command echo 'This step should be done before any other "nix develop" steps because of measuring Nix build time'
       - run: nix develop --command make deps


### PR DESCRIPTION
背景として https://determinate.systems/blog/installer-dropping-upstream/ の期限すら迫ってきているので、Nixを使っているつもりが少し違うNixを使うということになってしまうのを避けたいという感じです。
ざっくり言うと、これまで初心者向けという感じで使っていたものがコアな愛好者向けになってきているので、多分このリポジトリにはあんま向かないだろうなと

変更先の方が歴史が長く、自分もだいぶ前と最近の両方使ってて特に問題を感じないです。