### PR TITLE
カテゴリ一覧ページを本文全展開から要約表示に変更

### DIFF
--- a/themes/purehugo/layouts/_default/term.html
+++ b/themes/purehugo/layouts/_default/term.html
@@ -1,0 +1,31 @@
+{{ partial "header.html" . }}
+
+<div id="layout" class="pure-g">
+  {{ partial "sidebar.html" . }}
+
+  <div class="content pure-u-1 pure-u-md-3-4">
+    <div>
+      <h1 class="category-index-title">{{ .Title }}</h1>
+
+      <!-- A wrapper for all the blog posts -->
+      <div class="posts">
+        {{ range .Paginator.Pages }}
+          <article>
+            <!-- this <div> includes the title summary -->
+            <div>
+                <div class="content-subhead" style="border-bottom:none">{{ dateFormat "2006-01-02 15:04:05" .Date }}</div>
+                <div><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
+                <div class="post-description post-summary">{{ .Summary }}</div>
+            </div>
+            <hr>
+          </article>
+        {{ end }}
+      </div>
+      {{ partial "pagination.html" . }}
+      {{ partial "footer.html" . }}
+    </div>
+  </div>
+</div>
+{{ partial "analytics.html" . }}
+</body>
+</html>


### PR DESCRIPTION
## 概要

カテゴリを選んだ後の記事一覧（ターム）ページ `/categories/<term>/` で、各記事の本文が丸ごと展開され、一覧として本文が露出しすぎていた問題を修正します。トップページ（`index.html`）の表示に揃えます。

## 原因

`/categories/<term>/` は Hugo の term ページ（`kind=term`）で、専用テンプレートが無いため `_default/list.html`（本文を `{{ .Content }}` で全展開）にフォールバックしていました。

なお #429 で追加された `_default/terms.html` は `/categories/`（カテゴリ名の一覧, `kind=taxonomy`）専用で、term ページは対象外です。

## 変更内容

#429 が導入した「専用レイアウト」方針に沿い、term ページ用に **`_default/term.html` を新設**しました。記事ブロックは #427 で整えられたトップページ `index.html` と同一構造に揃えています。

- 本文全展開（`{{ .Content }}`）→ 要約（`{{ .Summary }}`）
- 抜粋は `.post-summary`（2行クランプ, #427 の CSS）で高さを揃える
- `Read More…` リンクは表示しない（タイトルが記事へのリンク）
- 記事間の区切りに `<hr>` を常時表示
- どのカテゴリを見ているか分かるよう `category-index-title` の見出しを付与
- `_default/list.html` は他の list 表示のため変更しない

## 補足（経緯）

当初は `_default/list.html` を直接書き換える実装でしたが、その後 main にマージされた #427（トップページの要約表示・Read More 廃止・`.post-summary` 追加）/ #429（`/categories/` 専用レイアウト）を取り込むため最新 main に rebase し、専用 `term.html` を新設する方針に変更しました。

## 検証

- `hugo --panicOnWarning` で静的ビルド成功（警告・エラーなし）
- 生成された `public/categories/go/index.html` の記事ブロックが `public/index.html` と同一構造であることを確認（素のタイトルリンク + `post-description post-summary` + `<hr>`、Read More なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
