### PR TITLE
カテゴリ一覧ページを専用レイアウトで整える

### DIFF
--- a/themes/purehugo/assets/css/blog.css
+++ b/themes/purehugo/assets/css/blog.css
@@ -224,6 +224,59 @@ h3 {
     color:#aaa
 }
 
+/* カテゴリ一覧 (/categories/) はタクソノミー terms ページ。
+   記事一覧用の list.html を流用すると意味のない投稿日・空の本文が並ぶため、
+   カテゴリ名と記事数だけを並べる専用レイアウトにしている。 */
+.category-index-title {
+    font-size: 1.8em;
+    color: #222;
+    font-family: "Oxygen", sans-serif;
+    font-weight: bold;
+    margin: 0.4em 0 0.8em;
+}
+.category-index {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6em;
+}
+.category-index-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.4em 0.9em;
+    border: 1px solid #d4dde4;
+    border-radius: 999px;
+    color: rgb(61, 146, 201);
+    background: #fff;
+    text-decoration: none;
+    transition: background .2s ease, border-color .2s ease, color .2s ease;
+}
+.category-index-item:hover,
+.category-index-item:focus {
+    background: rgb(61, 146, 201);
+    border-color: rgb(61, 146, 201);
+    color: #fff;
+    text-decoration: none;
+}
+.category-index-count {
+    min-width: 1.6em;
+    padding: 0 0.4em;
+    border-radius: 999px;
+    background: #eef3f7;
+    color: #6b6b6b;
+    font-size: 80%;
+    text-align: center;
+    line-height: 1.7;
+}
+.category-index-item:hover .category-index-count,
+.category-index-item:focus .category-index-count {
+    background: rgba(255, 255, 255, 0.25);
+    color: #fff;
+}
+
 @media (min-width: 48em) {
     .content {
         padding: 2em 3em 0;

--- a/themes/purehugo/layouts/_default/terms.html
+++ b/themes/purehugo/layouts/_default/terms.html
@@ -1,0 +1,29 @@
+{{ partial "header.html" . }}
+
+<div id="layout" class="pure-g">
+    {{ partial "sidebar.html" . }}
+
+    <div class="content pure-u-1 pure-u-md-3-4">
+        <div>
+            <h1 class="category-index-title">{{ .Title }}</h1>
+
+            {{ with .Data.Terms.ByCount }}
+            <ul class="category-index">
+                {{ range . }}
+                <li>
+                    <a class="category-index-item" href="{{ .Page.Permalink }}">
+                        <span class="category-index-name">{{ .Page.Title }}</span>
+                        <span class="category-index-count">{{ .Count }}</span>
+                    </a>
+                </li>
+                {{ end }}
+            </ul>
+            {{ end }}
+
+            {{ partial "footer.html" . }}
+        </div>
+    </div>
+</div>
+{{ partial "analytics.html" . }}
+</body>
+</html>


### PR DESCRIPTION
## 背景 / 問題

`/categories/`(全カテゴリ一覧 = タクソノミー terms ページ)が、ブログ記事一覧用の `_default/list.html` を流用して描画されていました。そのため各カテゴリが次の要素つきの「記事カード」として並び、レイアウトが崩れていました:

- 意味のない投稿日(`content-subhead`、`border-bottom` の罫線 = 見た目が変な hr)
- 空の著者欄(`post-meta`)
- 空の本文(`post-description`)

## 対応

Hugo の定石どおり `_default/terms.html` を新規追加し、terms ページ専用レイアウトにしました。

- 各カテゴリを「カテゴリ名 + 記事数バッジ」のピルとして、**記事数の降順**で表示(日本語カテゴリ名のアルファベット順問題も回避)
- ピルはホバーで反転するアクセシブルなリンク。色はテーマ既存のアクセント `rgb(61, 146, 201)` に統一
- `flex-wrap` でレスポンシブに折り返し

## 影響範囲

- `_default/terms.html` は terms ページ(Kind=`taxonomy`、`/categories/` と `/tags/`)だけに効く
- 個別カテゴリページ(Kind=`term`、`/categories/go/` など)は従来どおり `list.html` で記事を一覧表示(go = 7 記事のまま変化なしを確認)
- `/tags/` は現状タグ0件のため見出しのみ表示(`with` で空リストをスキップ)

## 確認

- `hugo --panicOnWarning` でビルド成功
- headless Chromium でデスクトップ・モバイル幅のスクリーンショットを取得し、ピルの折り返し・カウント表示・並び順を目視確認

## 変更ファイル

- `themes/purehugo/layouts/_default/terms.html`(新規)
- `themes/purehugo/assets/css/blog.css`(`.category-index*` を追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)