### PR TITLE
Bump tool versions

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/ci-nix.yml'
       - '*.nix'
       - 'flake.*'
+      - '.envrc'
       - 'Makefile'
       - 'print_dependencies.bash'
   pull_request:
@@ -13,6 +14,7 @@ on:
       - '.github/workflows/ci-nix.yml'
       - '*.nix'
       - 'flake.*'
+      - '.envrc'
       - 'Makefile'
       - 'print_dependencies.bash'
   schedule:
@@ -29,6 +31,13 @@ jobs:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
       - run: nix flake check
-      - run: nix develop --command echo 'This step should be done before any other "nix develop" steps because of measuring Nix build time'
-      - run: nix develop --command make deps
-      - run: nix develop --command make all
+      - name: Install direnv
+        run: |
+          url="$(nix eval --raw --impure --expr '(builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.nixpkgs.locked.url')"
+          nix profile add "${url}#direnv"
+      - name: Load environment variables
+        run: |
+          direnv allow .
+          direnv export gha > "$GITHUB_ENV"
+      - run: make deps
+      - run: make all

--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -16,8 +16,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: '0.141.0'
-      SASS_VERSION: '1.80.3'
+      HUGO_VERSION: '0.162.1'
+      SASS_VERSION: '1.100.0'
       DART_SASS_SHA_LINUX: 'a604a895666b24a7199dc42f3a144f39d7b7f5a7d3261ba7fde54fde5bf03764'
     steps:
       - name: Checkout

--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -16,8 +16,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: '0.162.1'
-      SASS_VERSION: '1.100.0'
+      HUGO_VERSION: '0.141.0'
+      SASS_VERSION: '1.80.3'
       DART_SASS_SHA_LINUX: '7c933edbad0a7d389192c5b79393485c088bd2c4398e32f5754c32af006a9ffd'
     steps:
       - name: Checkout

--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -16,8 +16,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: '0.141.0'
-      SASS_VERSION: '1.80.3'
+      HUGO_VERSION: '0.162.1'
+      SASS_VERSION: '1.100.0'
       DART_SASS_SHA_LINUX: '7c933edbad0a7d389192c5b79393485c088bd2c4398e32f5754c32af006a9ffd'
     steps:
       - name: Checkout

--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -18,7 +18,7 @@ jobs:
     env:
       HUGO_VERSION: '0.141.0'
       SASS_VERSION: '1.80.3'
-      DART_SASS_SHA_LINUX: '7c933edbad0a7d389192c5b79393485c088bd2c4398e32f5754c32af006a9ffd'
+      DART_SASS_SHA_LINUX: 'a604a895666b24a7199dc42f3a144f39d7b7f5a7d3261ba7fde54fde5bf03764'
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,4 +33,4 @@ jobs:
       - uses: actions/checkout@v6
       - uses: rvben/rumdl@546bd21b33a0401441a60d8f0c15431458ea6ab9 # v0
         with:
-          version: '0.0.194'
+          version: '0.2.5'

--- a/flake.lock
+++ b/flake.lock
@@ -2,18 +2,15 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765779637,
-        "narHash": "sha256-KJ2wa/BLSrTqDjbfyNx70ov/HdgNBCBBSQP3BIzKnv4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1306659b587dc277866c7b69eb97e5f07864d8c4",
-        "type": "github"
+        "lastModified": 1780336545,
+        "narHash": "sha256-bWVU1JP9hCYZzQjMLdMzr/FINF+UvpZGvCJcnNY616k=",
+        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1008784.4df1b885d76a/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     # How to update the revision: `nix flake update --commit-lock-file`
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
   };
 
   outputs =
@@ -26,7 +26,8 @@
               bashInteractive
               coreutils
               findutils # xargs
-              nixfmt-rfc-style
+              nixfmt
+              nixfmt-tree
               nixd
 
               gnumake
@@ -39,7 +40,7 @@
               dprint
 
               hugo
-              go_1_24
+              go_1_26
               dart-sass
 
               firebase-tools

--- a/hugo.toml
+++ b/hugo.toml
@@ -25,7 +25,7 @@ image = "https://avatars1.githubusercontent.com/u/6533008?s=460&v=4"
 paginate = 20
 
 [permalinks]
-posts = "/blog/:year/:month/:day/:filename/"
+posts = "/blog/:year/:month/:day/:contentbasename/"
 
 [markup]
 [markup.goldmark]


### PR DESCRIPTION
rumdl: Be latest. Higher than nixpkgs: https://github.com/pankona/pankona.github.io/pull/431#issuecomment-4609500979
hugo, sass: Same version as nixpkgs

```console
> make deps
./print_dependencies.bash
+ nix --version
nix (Nix) 2.34.7
+ hugo version
hugo v0.162.1+extended+withdeploy linux/amd64 BuildDate=unknown VendorInfo=nixpkgs
+ sass --version
1.100.0
+ go version
go version go1.26.3 linux/amd64
+ firebase --version
15.18.0

   ╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
   │                                                                                                                     │
   │                                         Update available 15.18.0 → 15.19.0                                          │
   │                                   To update to the latest version using npm, run                                    │
   │                                            npm install -g firebase-tools                                            │
   │   For other CLI management options, visit the CLI documentation (https://firebase.google.com/docs/cli#update-cli)   │
   │                                                                                                                     │
   │                                                                                                                     │
   │                                                                                                                     │
   ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

+ make --version
GNU Make 4.4.1
このプログラムは x86_64-pc-linux-gnu 用にビルドされました
Copyright (C) 1988-2023 Free Software Foundation, Inc.
ライセンス GPLv3+: GNU GPL バージョン 3 以降 <https://gnu.org/licenses/gpl.html>
これはフリーソフトウェアです: 自由に変更および配布できます.
法律の許す限り、　無保証　です.
+ dprint --version
dprint 0.54.0
+ typos --version
typos-cli 1.46.3
+ magick --version
Version: ImageMagick 7.1.2-23 Q16-HDRI x86_64 6c51b2de5:20260516 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/license/
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): bzlib cairo djvu fftw fontconfig freetype heic jng jp2 jpeg jxl lcms lqr openexr pangocairo png raqm raw rsvg tiff uhdr webp x xml zlib zstd
Compiler: gcc (15.2)
+ actionlint --version
1.7.12
installed by building from source
built with go1.26.3 compiler for linux/amd64
+ ls --version
ls (GNU coreutils) 9.11
Packaged by https://nixos.org
Copyright (C) 2026 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Richard M. Stallman and David MacKenzie.
+ nixfmt --version
nixfmt 1.3.1
+ nixd --version
nixd, version: 2.9.1
+ peco --version
peco version v0.6.0 (built with go1.26.3)
+ vim --version
+ sed -n 1p
VIM - Vi IMproved 9.2 (2026 Feb 14, compiled Jan 01 1980 00:00:00)
+ rumdl --version
rumdl 0.2.2
```
